### PR TITLE
Test runner URL fixes

### DIFF
--- a/handlers/Home.cfc
+++ b/handlers/Home.cfc
@@ -20,7 +20,7 @@ component{
 			instructions: "Bla bla bla."
 		}];
 
-		var testURL = "http://127.0.0.1:51741/modules/CFMLChallenge/tests/runner.cfm?reporter=json";
+		var testURL = "http://127.0.0.1:#cgi.server_port#/tests/runner.cfm?reporter=json";
 		cfhttp( url = testURL, method="GET", result="testResults" );
 		prc.testStats = DeSerializeJSON( testResults.filecontent );
 


### PR DESCRIPTION
Use the current port to access Testbox and correct the relative path to the module's runner